### PR TITLE
upgrade node version 10.18.0

### DIFF
--- a/st-node-nightmare/Dockerfile
+++ b/st-node-nightmare/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:10.15.0
+FROM node:10.18.0
 
 RUN apt-get update -y
 RUN apt-get install -yq gconf-service libasound2 libatk1.0-0 libc6 libcairo2 libcups2 libdbus-1-3 \


### PR DESCRIPTION
semantic-releaseの要求バージョンが10.18.0以降なので上げました